### PR TITLE
Allows apt and gem package state to be configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ fluentd_apt_repositories:
   - "deb http://packages.treasuredata.com/2/{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}/ {{ ansible_distribution_release | lower }} contrib"
 fluentd_packages:
   - td-agent
+fluentd_apt_package_state: latest
+fluentd_gem_state: latest
 fluentd_daemon: td-agent
 fluentd_config_path: /etc/td-agent
 fluentd_log_path: /var/log/td-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: install apt packages
   apt:
     name: "{{ item }}"
-    state: latest
+    state: "{{ fluentd_apt_package_state }}"
     install_recommends: no
     update_cache: yes
     cache_valid_time: 86400
@@ -34,7 +34,7 @@
   gem:
     name: "{{ item }}"
     executable: /opt/td-agent/embedded/bin/fluent-gem
-    state: latest
+    state: "{{ fluentd_gem_state }}"
     user_install: no
   with_items: "{{ fluentd_plugins }}"
   notify:


### PR DESCRIPTION
Use of `latest` is not idempotent - external changes can cause updates in Ansible when the configuration has not been changed. We generally don't want things to update on their own as it can cause things to break unexpectedly. 

This change allows the state of both apt and gem packages to be configured but keeps `latest` as the default.