### PR TITLE
Corrects sorting of match, filter and source configurations

### DIFF
--- a/templates/conf.d/filter.conf.j2
+++ b/templates/conf.d/filter.conf.j2
@@ -1,4 +1,4 @@
-{% for fluent_filter in fluentd_filter_config %}
+{% for fluent_filter in fluentd_filter_config | sort(attribute="name") %}
 <filter {{ fluent_filter["name"] }}>
 {% for key in fluent_filter|sort if key != "name" %}
 {% if key == "record" %}

--- a/templates/conf.d/match.conf.j2
+++ b/templates/conf.d/match.conf.j2
@@ -1,4 +1,4 @@
-{% for match in fluentd_match_config|sort %}
+{% for match in fluentd_match_config | sort(attribute="pattern") %}
 <match {{ match["pattern"] }}>
 {% for key in match|sort if key != "pattern" %}
 {% if key == "server" %}

--- a/templates/conf.d/source.conf.j2
+++ b/templates/conf.d/source.conf.j2
@@ -1,4 +1,4 @@
-{% for source in fluentd_source_config %}
+{% for source in fluentd_source_config | sort(attribute="@type") %}
 <source>
 {% for key in source|sort %}
   {{ key }} {{ source[key] }}


### PR DESCRIPTION
With multiple match configurations, the role encouters the error:
```
failed: [X.X.X.X] (item=conf.d/match.conf) => {"changed": false, "item": "conf.d/match.conf", "msg": "AnsibleError: Unexpected templating type error occurred on ({% for match in fluentd_match_config|sort %}\n<match {{ match[\"pattern\"] }}>\n{% for key in match|sort if key != \"pattern\" %}\n{% if key == \"server\" %}\n  <server>\n  {% for server_key in match[key]|sort %}\n    {{ server_key }} {{ match[key][server_key] }}\n  {% endfor %}\n  </server>\n{% else %}\n  {{ key }} {{ match[key] }}\n{% endif %}\n{% endfor %}\n</match>\n{% endfor %}\n): '<' not supported between instances of 'dict' and 'dict'"}
```

This PR corrects the sorting of match, filter and source configurations when they are templated.