### PR TITLE
Allow fluentd service settings to be defined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ fluentd_user: td-agent
 fluentd_usergroup: td-agent
 
 # fluentd basic configuration
+fluentd_system_service_settings:
+  TD_AGENT_OPTIONS: ""
+
 fluentd_system_config:
   process_name: ansible-fluentd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,11 @@
     - restart fluentd
   tags: fluentd_config
 
+- name: create td-agent service configuration
+  template:
+    src: service-settings.sh.j2
+    dest: /etc/default/td-agent
+
 - name: service start
   service:
     name: "{{ item }}"

--- a/templates/service-settings.sh.j2
+++ b/templates/service-settings.sh.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+# This file is sourced by /bin/sh from /etc/init.d/td-agent
+# Options to pass to td-agent
+{% for name, value in fluentd_system_service_settings.items() | sort %}
+{{ name }}="{{ value }}"
+{% endfor %}


### PR DESCRIPTION
This PR adds the ability for users to set fluentd service settings, such as `TD_AGENT_USER` (useful to get the service to run as `root`!) and `TD_AGENT_OPTIONS`.

